### PR TITLE
fix(generic): coerce undefined `data` into `null`

### DIFF
--- a/lib/generic.js
+++ b/lib/generic.js
@@ -231,7 +231,7 @@
        */
 
       XHR.prototype.call = function(params) {
-        var async, data, headers, method, name, type, url, value;
+        var async, data, headers, method, name, type, url, value, _ref;
         if (params == null) {
           params = {};
         }
@@ -240,13 +240,13 @@
         headers = params.headers || {};
         url = params.url;
         async = false !== params.async;
-        data = params.data;
+        data = (_ref = params.data) != null ? _ref : null;
         if (url == null) {
           throw new Error("Missing request URL");
         }
-        if ("GET" === method) {
+        if (data != null ? data : "GET" === method) {
           url = this.appendURL(url, data);
-          data = void 0;
+          data = null;
         }
         if (params.cache === false) {
           url = this.appendURL(url, +(new Date()));

--- a/src/generic.coffee
+++ b/src/generic.coffee
@@ -275,16 +275,22 @@
             headers = params.headers or {}
             url     = params.url
             async   = false isnt params.async
-            data    = params.data
+
+            # Ensure an undefined value for `data` is normalized to `null`.
+            #
+            # Letting `data` be `undefined`, at least on DELETE requests, causes IE to generate a 'Content-length: 9' header (9==='undefined'.length) and no body content.
+            # On a keep-alive connection, this will break any request that follows.
+            #
+            data    = params.data ? null
 
             throw new Error( "Missing request URL" ) if not url?
 
             # Add the request data to the URL if needed
             # Remember that we need to do this before the @open call
             #
-            if "GET" is method
+            if data ? "GET" is method
                 url  = @appendURL( url, data )
-                data = undefined
+                data = null
 
             # Check if we need to add a cache buster parameter
             #


### PR DESCRIPTION
This works around an IE10 bug exposed on DELETE requests, that would otherwise include a `Content-length: 9` header (`"undefined".length === 9`) but no body content on the request.

On a keep-alive connection this is sure to break any immediately following request. 

The issue is also found and discussed in angular/angular.js#12141
